### PR TITLE
nowrap.c - reorder variadic macros

### DIFF
--- a/nowrap.c
+++ b/nowrap.c
@@ -37,8 +37,8 @@ wprintw_nowrap (WINDOW *win, const char *fmt, ...)
 	char *p;		/* through buffer */
 
 	va_start(ap, fmt);	/* looks like i need to do this to pass */
-	va_end(ap);		/* arg list to vsnprintf(). */
 	vsnprintf(buffer, BUFFER_SIZE, fmt, ap);
+	va_end(ap);		/* arg list to vsnprintf(). */
 
 	getmaxyx(win, maxy, maxx);
 	for (p = buffer; *p; ++p) {


### PR DESCRIPTION
... so that `va_end` comes after `vsnprintf`'s use of `ap`.

Otherwise an optimising compiler can produce code that segfaults.

I don't know enough about compilers to know why, though this updated `va_start` -> `vsnprintf` -> `va_end` sequence feels appropriate.

Context: I was writing a FreeBSD port for `tdu` and it defaults to `-O2` on non-debug builds.

Thanks for `tdu`!